### PR TITLE
feat(plugin): 添加思维导图全屏预览功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ data.json
 main.js
 main1.js
 git-*.bat
+.DS_Store
+pnpm-lock.yaml

--- a/src/utils/genMM.js
+++ b/src/utils/genMM.js
@@ -18,7 +18,7 @@ const mmJson = require('./svg2img/mmJson.js')
 const svg2img = require('./svg2img/svg2img.js')
 module.exports = (app, ob)=> {
   const funcBtns = afterTransform(app, ob)
-  const customBar = (mm)=> {
+  const customBar = (mm, htmlText, sourcePath)=> {
     const bar = Toolbar.create(mm); bar.setBrand(!1) // hide markmap logo & url
 
     bar.register({
@@ -32,11 +32,32 @@ module.exports = (app, ob)=> {
         }}).click()
       },
     })
+    
+    // 添加全屏按钮 - 修改为传递markmap内容
+    bar.register({
+      id: 'fullscreen', content: '', title: '全屏显示',
+      onClick: async ()=> {
+        // 获取当前的transformer和root，以便获取原始的markdown内容
+        const leaf = app.workspace.getLeaf('split')
+        await leaf.setViewState({ 
+          type: 'mm-block-view', 
+          state: {
+            sourcePath: sourcePath,
+            htmlContent: htmlText,
+            // 传递原始内容，用于在新视图中渲染
+            originalContent: mm.state.data.payload 
+          }
+        })
+      },
+    })
 
-    bar.setItems([...Toolbar.defaultItems, 'export-as-img'])
+    bar.setItems([...Toolbar.defaultItems, 'export-as-img', 'fullscreen'])
     const barEl = bar.render()
     ob.setIcon(barEl.children[4], 'download')
     barEl.children[4].firstChild.setCssProps({width: '16px', height: '20px'})
+    // 设置全屏按钮图标
+    ob.setIcon(barEl.children[5], 'maximize-2')
+    barEl.children[5].firstChild.setCssProps({width: '16px', height: '20px'})
     return barEl
   }
   const genMM = async (wrapper, htmlText, sourcePath, printHeight)=> {
@@ -50,7 +71,7 @@ module.exports = (app, ob)=> {
       // seems markmap@0.18 requires calling fit() again before exporting a PDF
       await svg2img(svg, printHeight)
     }
-    else wrapper.append(customBar(mm))
+    else wrapper.append(customBar(mm, htmlText, sourcePath))
   }
   const genMM2 = (ob.debounce)(genMM)
   return { genMM, genMM2 }

--- a/src/utils/mmBlock.js
+++ b/src/utils/mmBlock.js
@@ -1,11 +1,15 @@
 module.exports = (plg, ob)=> {
-  const md2htmlText = require('./getText/md2htmlText.js')(app, ob)
+  const md2htmlText = require('./getText/md2htmlText.js')(plg.app, ob)
   const { genMM } = require('./genMM.js')(plg.app, ob)
   const mmBlock = async (source, el, ctx)=> {
     const fmRgx = new RegExp(String.raw`---\nmarkmap:\n  height: (\d+)\n---\n`, '')
     let height
     const md = source.replace(fmRgx, (m, p1)=> { height = p1; return '' })
     el.style.height = `${height||400}px`
+    
+    // 保存原始内容到元素上，以便后续全屏使用
+    el.setAttribute('data-markmap-source', md)
+    
     const text = await md2htmlText(md, ctx.sourcePath)
     if (ctx.el.parentNode?.className == 'print') {
       await genMM(el, text, ctx.sourcePath, height||!0)


### PR DESCRIPTION
>[!note]
>借助AI添加了一个markmap代码块中渲染的思维导图在分割视图中全屏展示的功能，使用场景在于一些一些较长的思维导图作为代码块在笔记中缩放受限，若将高度调的太高又会影响其他内容的阅读

>[!warning]
> 事实上也可以将该代码块内容移动到一个新文件，然后使用插件原本的`'Markmap active note'`功能展示，但是我个人更偏向于将脑图与笔记内容放在一块，因为他们是一个整体

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/72844f33-8a57-45bc-afe1-a4f274ff2279" />

以下是修改内容，AI生成可能会有一些多余的成分，我已做过基本的测试，暂时没有发现明显的BUG

- 在 genMM.js 中添加全屏按钮，点击后在新视图中显示完整的 markmap 内容
- 新增 mmBlockView 类用于全屏预览，支持单独视口显示思维导图
- 修改 mmBlock.js，为每个思维导图块添加 data-markmap-source 属性
- 更新 mmView.js，增加对全屏预览的支持

